### PR TITLE
Implementation of mass constraint option

### DIFF
--- a/interface/ClassicSVfit.h
+++ b/interface/ClassicSVfit.h
@@ -24,6 +24,8 @@ class ClassicSVfit
   /// add an additional log(mTauTau) term to the nll to suppress high mass tail in mTauTau distribution (default is false)
   void addLogM_fixed(bool value, double power = 1.);
   void addLogM_dynamic(bool value, const std::string& power = "");
+  
+  void setDiTauMassConstraint(double diTauMass);
 
 #ifdef USE_SVFITTF
   /// set transfer functions for pT of hadronic tau decays
@@ -65,6 +67,8 @@ class ClassicSVfit
 
   std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptons_;
   classic_svFit::Vector met_;
+  
+  double diTauMassConstraint_ = -1.0;
 
   /// interface to Markov Chain integration algorithm
   classic_svFit::SVfitIntegratorMarkovChain* intAlgo_;

--- a/interface/ClassicSVfitIntegrand.h
+++ b/interface/ClassicSVfitIntegrand.h
@@ -32,6 +32,8 @@ namespace classic_svFit
     /// add an additional log(mTauTau) term to the nll to suppress high mass tail in mTauTau distribution (default is false)
     void addLogM_fixed(bool value, double power = 1.);
     void addLogM_dynamic(bool value, const std::string& power= "");
+    
+    void setDiTauMassConstraint(double diTauMass);
 
     /// set pointer to histograms used to keep track of pT, eta, phi, mass and transverse mass of di-tau system
     /// during Markov Chain integration
@@ -137,6 +139,8 @@ namespace classic_svFit
     double addLogM_fixed_power_;
     bool addLogM_dynamic_;
     TFormula* addLogM_dynamic_formula_;
+    
+    double diTauMassConstraint_ = -1.0;
 
     /// error code that can be passed on
     int errorCode_;

--- a/src/ClassicSVfit.cc
+++ b/src/ClassicSVfit.cc
@@ -64,6 +64,12 @@ void ClassicSVfit::addLogM_dynamic(bool value, const std::string& power)
   integrand_->addLogM_dynamic(value, power);
 }
 
+void ClassicSVfit::setDiTauMassConstraint(double diTauMass)
+{
+  diTauMassConstraint_ = diTauMass;
+  integrand_->setDiTauMassConstraint(diTauMassConstraint_);
+}
+
 #ifdef USE_SVFITTF
 void ClassicSVfit::setHadTauTF(const HadTauTFBase* hadTauTF)
 {
@@ -213,8 +219,10 @@ ClassicSVfit::integrate(const std::vector<MeasuredTauLepton>& measuredTauLeptons
 	    }
     }
     if ( idx == 1 ) {
-      idxLeg2_X = numDimensions_;
-      numDimensions_ += 1;
+      if (diTauMassConstraint_ < 0.0) {
+        idxLeg2_X = numDimensions_;
+        numDimensions_ += 1;
+      }
       idxLeg2_phi = numDimensions_;
       numDimensions_ += 1;
       if ( measuredTauLepton.type() == MeasuredTauLepton::kTauToHadDecay ) {
@@ -290,12 +298,14 @@ ClassicSVfit::integrate(const std::vector<MeasuredTauLepton>& measuredTauLeptons
     xl_[idxLeg1_mNuNu] = 0.;
     xu_[idxLeg1_mNuNu] = tauLeptonMass2;
   }
-  xl_[idxLeg2_X] = 0.;
+  if (idxLeg2_X != -1) {
+    xl_[idxLeg2_X] = 0.;
 #ifdef USE_SVFITTF
-  xu_[idxLeg2_X] = 2.; // upper integration bound for x2' = visPtShift2*x2
+    xu_[idxLeg2_X] = 2.; // upper integration bound for x2' = visPtShift2*x2
 #else
-  xu_[idxLeg2_X] = 1.;
+    xu_[idxLeg2_X] = 1.;
 #endif
+  }
   xl_[idxLeg2_phi] = -TMath::Pi();
   xu_[idxLeg2_phi] = +TMath::Pi();
   if ( idxLeg2VisPtShift != -1 ) {

--- a/src/ClassicSVfitIntegrand.cc
+++ b/src/ClassicSVfitIntegrand.cc
@@ -93,6 +93,11 @@ void ClassicSVfitIntegrand::addLogM_dynamic(bool value, const std::string& power
   }
 }
 
+void ClassicSVfitIntegrand::setDiTauMassConstraint(double diTauMass)
+{
+  diTauMassConstraint_ = diTauMass;
+}
+
 void ClassicSVfitIntegrand::setHistogramAdapter(HistogramAdapter* histogramAdapter)
 {
   histogramAdapter_ = histogramAdapter;
@@ -291,8 +296,13 @@ ClassicSVfitIntegrand::Eval(const double* x) const
   double x1 = x1_dash/visPtShift1;
   if ( !(x1 >= 1.e-5 && x1 <= 1.) ) return 0.;
 
-  assert(idxLeg2_X_ != -1);
-  double x2_dash = x[idxLeg2_X_];
+  double x2_dash = 0.0;
+  if (idxLeg2_X_ != -1) {
+    x2_dash = x[idxLeg2_X_];
+  }
+  else {
+    x2_dash = (measuredTauLepton1_.p4() + measuredTauLepton2_.p4()).M2()/(x1_dash * diTauMassConstraint_);
+  }
   double x2 = x2_dash/visPtShift2;
   if ( !(x2 >= 1.e-5 && x2 <= 1.) ) return 0.;
 

--- a/src/ClassicSVfitIntegrand.cc
+++ b/src/ClassicSVfitIntegrand.cc
@@ -301,7 +301,7 @@ ClassicSVfitIntegrand::Eval(const double* x) const
     x2_dash = x[idxLeg2_X_];
   }
   else {
-    x2_dash = (measuredTauLepton1_.p4() + measuredTauLepton2_.p4()).M2()/(x1_dash * diTauMassConstraint_ * diTauMassConstraint_);
+    x2_dash = (measuredTauLepton1_.p4() + measuredTauLepton2_.p4()).M2()/(diTauMassConstraint_ * diTauMassConstraint_)/x1_dash;
   }
   double x2 = x2_dash/visPtShift2;
   if ( !(x2 >= 1.e-5 && x2 <= 1.) ) return 0.;
@@ -445,6 +445,9 @@ ClassicSVfitIntegrand::Eval(const double* x) const
   }
 
   double jacobiFactor = 1./(visPtShift1*visPtShift2); // product of derrivatives dx1/dx1' and dx2/dx2' for parametrization of x1, x2 by x1', x2'
+  if (diTauMassConstraint_ > 0.0) {
+    jacobiFactor *= (2.0*x2*diTauMassConstraint_);
+  }
   double prob = prob_PS_and_tauDecay*prob_TF*prob_logM*jacobiFactor;
   if ( verbosity_ >= 2 ) {
     std::cout << "prob: PS+decay = " << prob_PS_and_tauDecay << ","

--- a/src/ClassicSVfitIntegrand.cc
+++ b/src/ClassicSVfitIntegrand.cc
@@ -301,7 +301,7 @@ ClassicSVfitIntegrand::Eval(const double* x) const
     x2_dash = x[idxLeg2_X_];
   }
   else {
-    x2_dash = (measuredTauLepton1_.p4() + measuredTauLepton2_.p4()).M2()/(x1_dash * diTauMassConstraint_);
+    x2_dash = (measuredTauLepton1_.p4() + measuredTauLepton2_.p4()).mass()/(x1_dash * diTauMassConstraint_);
   }
   double x2 = x2_dash/visPtShift2;
   if ( !(x2 >= 1.e-5 && x2 <= 1.) ) return 0.;

--- a/src/ClassicSVfitIntegrand.cc
+++ b/src/ClassicSVfitIntegrand.cc
@@ -301,7 +301,7 @@ ClassicSVfitIntegrand::Eval(const double* x) const
     x2_dash = x[idxLeg2_X_];
   }
   else {
-    x2_dash = (measuredTauLepton1_.p4() + measuredTauLepton2_.p4()).mass()/(x1_dash * diTauMassConstraint_);
+    x2_dash = (measuredTauLepton1_.p4() + measuredTauLepton2_.p4()).M2()/(x1_dash * diTauMassConstraint_ * diTauMassConstraint_);
   }
   double x2 = x2_dash/visPtShift2;
   if ( !(x2 >= 1.e-5 && x2 <= 1.) ) return 0.;


### PR DESCRIPTION
The code should follow your instructions:


in order to constrain the mass of the tau pair to mZ or to mH, what you need to do is:
- write function that allows to setMass(double mH) in SVfitStandaloneAlgorithm.h
- eliminate one of the integration variables (either x1 or x2; I propose you eliminate x2)
- set x2 = mVis^2/(x1*mH^2)
- add Jacobi factor to integrand in case setMass(double mH) has been called by the user
	The Jacobi factor is due to the fact that you are eliminating the integration over x2,
	but the delta function is delta(mH - mVis/(sqrt(x1*x2)), so the delta function rule
		https://en.wikipedia.org/wiki/Dirac_delta_function#Composition_with_a_function
        needs to be applied.
        g(x2) = mVis^2/(x1*mH^2) -> dg/dx2 = mH/(2*x2) 
     -> delta(mH - mVis/(sqrt(x1*x2)) = delta(mVis^2/(x1*mH^2) - x2)*2*x2*mH
     -> Jacobi factor = 2*x2*mH