### PR TITLE
Fixed tests

### DIFF
--- a/src/svFitHistogramAdapter.cc
+++ b/src/svFitHistogramAdapter.cc
@@ -214,7 +214,9 @@ TH1* TransverseMassSVfitQuantity::createHistogram(const LorentzVector& vis1P4, c
 
 double TransverseMassSVfitQuantity::fitFunction(const LorentzVector& tau1P4, const LorentzVector& tau2P4, const LorentzVector& vis1P4, const LorentzVector& vis2P4, const Vector& met) const
 {
-  return TMath::Sqrt(2.0*tau1P4.pt()*tau2P4.pt()*(1.0 - TMath::Cos(tau1P4.phi() - tau2P4.phi())));
+  classic_svFit::LorentzVector fittedDiTauSystem = tau1P4 + tau2P4;
+  double transverseMass2 = square(tau1P4.Et() + tau2P4.Et()) - (square(fittedDiTauSystem.px()) + square(fittedDiTauSystem.py()));
+  return TMath::Sqrt(TMath::Max(1., transverseMass2));
 }
 
 


### PR DESCRIPTION
Hi Christian,

I fixed the test script now such, that expectation and results agree. I am sorry, that one change (https://github.com/veelken/ClassicSVfit/pull/6/commits/60377657a42a58e413aea524aa30a6e4b46f9fe4) already made it in the previous PR. In this change I updated the expectation in the test script to the values of I get after the second commit in this repository, which I consider as initial version. These values are still obtained. In the change of this PR I reverted the definition of the transverse mass to the one of your initial version, which is like this then different from the Standalone version (which therefore might again justify the different repositories ;-)).

Regards,
Thomas