### PR TITLE
* fix Jacobi factor for the integration over x2 with Dirac delta

### DIFF
--- a/src/ClassicSVfitIntegrand.cc
+++ b/src/ClassicSVfitIntegrand.cc
@@ -446,7 +446,7 @@ ClassicSVfitIntegrand::Eval(const double* x) const
 
   double jacobiFactor = 1./(visPtShift1*visPtShift2); // product of derrivatives dx1/dx1' and dx2/dx2' for parametrization of x1, x2 by x1', x2'
   if (diTauMassConstraint_ > 0.0) {
-    jacobiFactor *= (2.0*x2*diTauMassConstraint_);
+    jacobiFactor *= (2.0*x2/diTauMassConstraint_);
   }
   double prob = prob_PS_and_tauDecay*prob_TF*prob_logM*jacobiFactor;
   if ( verbosity_ >= 2 ) {


### PR DESCRIPTION
Fix Jacobi factor for the integration over x2 with delta[mH - sqrt(mVis/x1/x2)].
The correction comes from derivative over x2. Also with this correction I get perfect agreement betwenn Cuba and MC shapes of integral result as a function of assumed mass:
![mcvscuba](https://user-images.githubusercontent.com/4928163/27226488-9cedacfc-529f-11e7-8444-f50862a06777.png)
